### PR TITLE
Allow non-JSON data

### DIFF
--- a/docker-hook
+++ b/docker-hook
@@ -33,9 +33,13 @@ class RequestHandler(BaseHTTPRequestHandler):
         env = dict(os.environ)
         json_params = {}
         if len(json_payload) > 0:
-            json_params = json.loads(json_payload)
-            env.update(('REPOSITORY_' + var.upper(), str(val))
-                       for var, val in json_params['repository'].items())
+            try:
+                json_params = json.loads(json_payload)
+                env.update(('REPOSITORY_' + var.upper(), str(val))
+                           for var, val in json_params['repository'].items())
+            except:
+                 # If not JSON encoded, this is not a problem and should not fail
+                pass
 
         # Check if the secret URL was called
         token = args.token or os.environ.get("DOCKER_AUTH_TOKEN")


### PR DESCRIPTION
If the hook called includes data, which is not JSON format, this will cause an exception. In my case, this is a problem if using hooks from Slack, and I assume others.
This patch silently ignores the exception, if the JSON fails to parse.