### PR TITLE
Fix use of getheader function

### DIFF
--- a/docker-hook
+++ b/docker-hook
@@ -28,7 +28,7 @@ class RequestHandler(BaseHTTPRequestHandler):
 
     def do_POST(self):
         logging.info("Path: %s", self.path)
-        header_length = int(self.headers.getheader('content-length', "0"))
+        header_length = int(self.headers.get('content-length', "0"))
         json_payload = self.rfile.read(header_length)
         env = dict(os.environ)
         json_params = {}


### PR DESCRIPTION
The getheader function is a python2 alias for get, but it does not exist in python3.
Replace use of getheader with get.

Reference: https://bugs.launchpad.net/python-keystoneclient/+bug/1267987.