### PR TITLE
Properly decode bytes message

### DIFF
--- a/docker-hook
+++ b/docker-hook
@@ -33,7 +33,7 @@ class RequestHandler(BaseHTTPRequestHandler):
         env = dict(os.environ)
         json_params = {}
         if len(json_payload) > 0:
-            json_params = json.loads(json_payload)
+            json_params = json.loads(json_payload.decode('utf-8')))
             env.update(('REPOSITORY_' + var.upper(), str(val))
                        for var, val in json_params['repository'].items())
 


### PR DESCRIPTION
Python3 payloads are of type bytes, and cannot be used with json.loads.
Decode bytes before reading payload.